### PR TITLE
Removes hint comments from JS and HTML

### DIFF
--- a/Develop/index.html
+++ b/Develop/index.html
@@ -21,18 +21,7 @@
     <p id="currentDay" class="lead"></p>
   </header>
   <div class="container-fluid px-5">
-    <!-- Use class for "past", "present", and "future" to apply styles to the
-        time-block divs accordingly. The javascript will need to do this by
-        adding/removing these classes on each div by comparing the hour in the
-        id to the current hour. The html provided below is meant to be an example
-        demonstrating how the css provided can be leveraged to create the
-        desired layout and colors. The html below should be removed or updated
-        in the finished product. Remember to delete this comment once the
-        code is implemented.
-        -->
-
-    <!-- Example of a past time block. The "past" class adds a gray background color. -->
-    <div id="hour-9" class="row time-block past">
+    <div id="hour-9" class="row time-block">
       <div class="col-2 col-md-1 hour text-center py-3">9AM</div>
       <textarea class="col-8 col-md-10 description" rows="3"> </textarea>
       <button class="btn saveBtn col-2 col-md-1" aria-label="save">
@@ -41,8 +30,7 @@
       </button>
     </div>
 
-    <!-- Example of a present time block. The "present" class adds a red background color. -->
-    <div id="hour-10" class="row time-block present">
+    <div id="hour-10" class="row time-block">
       <div class="col-2 col-md-1 hour text-center py-3">10AM</div>
       <textarea class="col-8 col-md-10 description" rows="3"> </textarea>
       <button class="btn saveBtn col-2 col-md-1" aria-label="save">
@@ -50,8 +38,7 @@
       </button>
     </div>
 
-    <!-- Example of a future time block. The "future" class adds a green background color. -->
-    <div id="hour-11" class="row time-block future">
+    <div id="hour-11" class="row time-block">
       <div class="col-2 col-md-1 hour text-center py-3">11AM</div>
       <textarea class="col-8 col-md-10 description" rows="3"> </textarea>
       <button class="btn saveBtn col-2 col-md-1" aria-label="save">

--- a/Develop/script.js
+++ b/Develop/script.js
@@ -1,33 +1,16 @@
-// Wrap all code that interacts with the DOM in a call to jQuery to ensure that
-// the code isn't run until the browser has finished rendering all the elements
-// in the html.
-
-//note: id attributes are formatted as id="hour-#" for each div block
 $(function () {
-  // TODO: Add a listener for click events on the save button. DONE
-  // TODO: This code should use the id in the containing time-block as a key to save the user input in local storage.
-  // HINT: What does `this` reference in the click listener
-  // function? How can DOM traversal be used to get the "hour-x" id of the
-  // time-block containing the button that was clicked? How might the id be
-  // useful when saving the description in local storage?
-  //
 
-
-  // TODO: Add code to get any user input that was saved in localStorage and set
-  // the values of the corresponding textarea elements. HINT: How can the id
-  // attribute of each time-block be used to do this?
-  //
-
+  //This is a click event function that allows the user to save their events when they click the save button.
   $(".saveBtn").click(function (e) {
     e.preventDefault();
-    //TODO: have the events match with id as a key, using "this"
     //This function takes the value of the description sibling of this (the one the user clicked) "saveBtn"/save button class
     var userInput = $(this).siblings(".description").val();
-    // console.log(userInput);
     //This function takes the value of the hour sibling of this (the one the user clicked) "saveBtn"/save button class
     var thisHour = $(this).siblings(".hour").text();
-    //The two variable will be stored in local storage by setting the key (x,y) items with x being the stringified value of thisHour and y being the stringified value of the description sibling.
+    //The two variable will be stored in local storage by setting the key (x,y) items with x being thisHour and y being the stringified value of the description sibling.
     localStorage.setItem(thisHour, JSON.stringify(userInput));
+    //Do not stringify the keyname (in this case, thisHour)! When you try getItem it won't be the same as a stringified "9AM".
+    //ex: JSON.stringify(9AM) = "9AM" but JSON.parse(localStorage.getItem("9AM")) = 9AM, therefore you can't access the item because it doesn't exist.
   });
 
   //Each hour's text box will display what was stored even after refreshing
@@ -79,8 +62,8 @@ $(function () {
       }
     }
   }
-  colorBlocking();
 
+  colorBlocking();
 
   // TODO: Add code to display the current date in the header of the page.
   var today = dayjs();


### PR DESCRIPTION
This update removes the hint comments that were initially provided in the HTML and JS as well as the sample past, present, and future class tags.